### PR TITLE
PL-3035 Limit to 2 the minimum threads used in parallel extraction

### DIFF
--- a/src/porespy/networks/_getnet_para.py
+++ b/src/porespy/networks/_getnet_para.py
@@ -212,7 +212,7 @@ def regions_to_network_parallel(
     vertex_index_array = vertex_index_array.reshape((2, 2, 2), order="F")
 
     if threads is None:
-        threads = (numba.config.NUMBA_NUM_THREADS - 2) // 2
+        threads = max((numba.config.NUMBA_NUM_THREADS - 2) // 2, 2)
 
     im = make_contiguous(regions)
     # struc_elem = disk if im.ndim == 2 else ball


### PR DESCRIPTION
This solves a bug in Geoslicer Cloud, in which the number of threads is calculated to 1.
So we are temporarily setting a minimum of 2 to avoid the error.