### PR TITLE
Issue #11 Solving the unit tests workflows and lint errors

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           uv sync --group test --group build --extra extras
           uv build
+          uv pip install dist/porespy-*.whl
 
       - name: Setup FFmpeg
         uses: AnimMouse/setup-ffmpeg@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-    "dask",
+    "dask[distributed]",
     "deprecated",
     "edt",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "numba",
     "numpy",
     "pandas",
+    "pyedt",
     "psutil",
     "rich",
     "scikit-image>=0.25.0",

--- a/src/porespy/networks/_getnet_para.py
+++ b/src/porespy/networks/_getnet_para.py
@@ -14,7 +14,6 @@ from porespy.tools import (
     get_edt,
     jit_extend_slice,
     jit_marching_cubes_area_and_volume,
-    jit_marching_squares_perimeter_and_area,
     make_contiguous,
     pad,
 )
@@ -384,7 +383,7 @@ def _get_throats(
                     (0, 0, -1, 2),
                     (0, 0, 1, 2),
                 )
-    
+
     areas_projections = {
         0: {-1: 0.},
         1: {-1: 0.},
@@ -401,7 +400,7 @@ def _get_throats(
                     y2 = y + dy
                     z2 = z + dz
                     if pore_im[x2, y2, z2] == 0:
-                        
+
                         neighbour_pore_label = sub_im[x2, y2, z2]
                         neighbour_pore_id = neighbour_pore_label - 1
                         if neighbour_pore_id == -1:
@@ -439,8 +438,8 @@ def _get_throats(
                                 (y2) * voxel_size[1],
                                 (z2) * voxel_size[2],
                                 )
-                            
-                        ### Check if is border
+
+                        # Check if is border
                         perimeter = 0
                         try:
                             if (ax == 0) and (dx == 1):


### PR DESCRIPTION
I'm trying to solve the following 3 errors in the CI/CD environment:
- Missing package installation in CI: the run-examples.yml workflow now installs the built wheel with uv pip install dist/porespy-*.whl after uv build, so the examples run against the packaged distribution;
- Ruff lint failures corrected;
- Test collection failure (ModuleNotFoundError: No module named 'distributed'): src/porespy/filters/_snows.py does a module-level import dask.distributed. Since porespy/__init__.py imports filters, every import porespy failed at collection, causing all 30 test modules to error out. The dask dependency was declared without the required extra, so I changed it to dask[distributed] in pyproject.toml;
- Adds pyedt as dependency in pyproject.toml;